### PR TITLE
File.exists? and Dir.exists? are deprecated

### DIFF
--- a/lib/classy/yaml/component_helpers.rb
+++ b/lib/classy/yaml/component_helpers.rb
@@ -4,7 +4,7 @@ module Classy
       def yass(*args)
         component_name = caller.first.split("/").last.split(".").first
         calling_path = caller.first.split("/")[0...-1].join("/")
-        classy_file = if Dir.exists?("#{calling_path}/#{component_name}")
+        classy_file = if Dir.exist?("#{calling_path}/#{component_name}")
                         "#{calling_path}/#{component_name}/#{component_name}.yml"
                       else
                         "#{calling_path}/#{component_name}.yml"

--- a/lib/classy/yaml/helpers.rb
+++ b/lib/classy/yaml/helpers.rb
@@ -3,12 +3,12 @@ module Classy
     module Helpers
       def yass(*args)
         classy_yamls = []
-        classy_yamls << YAML.load_file(Rails.root.join("config/utility_classes.yml")) if File.exists?(Rails.root.join("config/utility_classes.yml"))
+        classy_yamls << YAML.load_file(Rails.root.join("config/utility_classes.yml")) if File.exist?(Rails.root.join("config/utility_classes.yml"))
 
         classy_files_hash = args.find { |arg| arg.is_a?(Hash) && arg.keys.include?(:classy_files) }
         if classy_files_hash.present?
           classy_files_hash[:classy_files].each do |file|
-            if File.exists?(file) && YAML.load_file(file)
+            if File.exist?(file) && YAML.load_file(file)
               file = YAML.load_file(file)
               classy_yamls << file if file
             end


### PR DESCRIPTION
This PR changes `File.exists?` and `Dir.exists?` to `File.exist?` and `Dir.exist?`, respectively. The former are now deprecated with Rails 7.